### PR TITLE
Allow batch ordering

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -9,7 +9,7 @@
     "start": "node ./bin/www",
     "lint": "node_modules/.bin/eslint . --no-fix --ext .js",
     "lint:fix": "node_modules/.bin/eslint . --fix --ext .js",
-    "test": "node_modules/.bin/jest --verbose",
+    "test": "node_modules/.bin/jest --verbose --no-cache",
     "clean": "rm -rf coverage dist",
     "pretest": "npm run lint",
     "purge": "rm -rf node_modules",

--- a/app/src/components/messageParser.js
+++ b/app/src/components/messageParser.js
@@ -29,7 +29,7 @@ const messageParser = {
     const txid = uuid.v4();
     const ts = moment.utc().valueOf();
     obj.forEach((item, idx) => {
-      item.transaction = {batch: {id: txid, size: obj.length, itemId:idx+1, timestamp:ts}};
+      item.transaction = {batch: {id: txid, size: obj.length, itemId: idx+1, timestamp: ts}};
     });
     return await Promise.all(obj.map(entry => messageParser.parse(authorizedParty, entry)));
   },

--- a/app/tests/unit/components/messageParser.spec.js
+++ b/app/tests/unit/components/messageParser.spec.js
@@ -55,7 +55,40 @@ describe('parseMany', () => {
     expect(result[0]).toEqual(clogs);
     expect(result[1]).toEqual(clogs);
     expect(parseSpy).toHaveBeenCalledTimes(2);
-    expect(parseSpy).toHaveBeenCalledWith(azp, loggingEntryBase);
+    //expect(parseSpy).toHaveBeenCalledWith(azp, loggingEntryBase);
+  });
+
+  it('should return an array of CLOGS objects in a batch', async () => {
+    parseSpy.mockImplementation(async (authorizedParty, obj) => {
+      const clogs = {
+        client: authorizedParty,
+        level: 'info',
+        retention: 'default',
+        timestamp: moment.utc().valueOf(),
+        env:'dev'
+      };
+      Object.assign(clogs, obj.metadata);
+      Object.assign(clogs, obj.transaction);
+      return { clogs: clogs };
+    });
+
+    const obj = [
+      Object.assign({}, loggingEntryBase),
+      Object.assign({}, loggingEntryBase)
+    ];
+
+    const result = await messageParser.parseMany(azp, obj);
+
+    expect(result).toBeTruthy();
+    expect(Array.isArray(result)).toBeTruthy();
+    expect(result).toHaveLength(2);
+    expect(result[0].clogs.batch).toBeTruthy();
+    expect(result[1].clogs.batch).toBeTruthy();
+    expect(result[0].clogs.batch.id).toEqual(result[1].clogs.batch.id);
+    expect(result[0].clogs.batch.timestamp).toEqual(result[1].clogs.batch.timestamp);
+    expect(result[0].clogs.batch.itemId).toEqual(1);
+    expect(result[1].clogs.batch.itemId).toEqual(2);
+
   });
 });
 

--- a/app/tests/unit/components/messageParser.spec.js
+++ b/app/tests/unit/components/messageParser.spec.js
@@ -82,6 +82,9 @@ describe('parseMany', () => {
     expect(result).toBeTruthy();
     expect(Array.isArray(result)).toBeTruthy();
     expect(result).toHaveLength(2);
+    expect(parseSpy).toHaveBeenCalledTimes(2);
+    expect(parseSpy).toHaveBeenCalledWith(azp, obj[0]);
+    expect(parseSpy).toHaveBeenCalledWith(azp, obj[1]);
     expect(result[0].clogs.batch).toBeTruthy();
     expect(result[1].clogs.batch).toBeTruthy();
     expect(result[0].clogs.batch.id).toEqual(result[1].clogs.batch.id);


### PR DESCRIPTION
Both the parser service and the logstash service are using promise.all(), that mean lists of items are processed in whatever order is quickest.  So timestamps on clogs objects do not reflect the order that items were received.  We want to retain that ordering...

However, Promise.all() is significantly faster than sequential, so to retain order we add a batch object that will provide details (batch id, item id, timestamp and size of batch).  This provides a mechanism to order the objects sequentially in kibana (if desired).

[SHOWCASE-857](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-857)

<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the OpenAPI 3.0 `v*.api-spec.yaml` documentation (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
